### PR TITLE
feat(cli): add lingui check command for sync and missing validations

### DIFF
--- a/packages/cli/src/api/catalog/translations.ts
+++ b/packages/cli/src/api/catalog/translations.ts
@@ -1,0 +1,56 @@
+import normalizePath from "normalize-path"
+import nodepath from "path"
+import { Catalog } from "../catalog.js"
+import { CheckFindingBase } from "../findings.js"
+import {
+  getTranslationsForCatalog,
+  TranslationMissingEvent,
+} from "./getTranslationsForCatalog.js"
+
+export type MissingTranslationFinding = CheckFindingBase & {
+  code: "missing_translation"
+  locale: string
+}
+
+function createMissingTranslationMessage(messageId: string, source?: string) {
+  return source || source === messageId
+    ? `${messageId}: (${source})`
+    : messageId
+}
+
+export async function getCatalogTranslationsWithMissing(
+  catalog: Catalog,
+  locale: string,
+) {
+  const { messages, missing } = await getTranslationsForCatalog(
+    catalog,
+    locale,
+    {
+      fallbackLocales: catalog.config.fallbackLocales,
+      sourceLocale: catalog.config.sourceLocale,
+      missingBehavior: "catalog",
+    },
+  )
+
+  return {
+    messages,
+    missing,
+  }
+}
+
+export function createMissingTranslationFinding(
+  catalog: Catalog,
+  locale: string,
+  missing: TranslationMissingEvent,
+): MissingTranslationFinding {
+  const catalogPath = normalizePath(
+    nodepath.relative(catalog.config.rootDir, catalog.getFilename(locale)),
+  )
+
+  return {
+    code: "missing_translation",
+    locale,
+    catalogPath,
+    message: createMissingTranslationMessage(missing.id, missing.source),
+  }
+}

--- a/packages/cli/src/api/check/index.ts
+++ b/packages/cli/src/api/check/index.ts
@@ -1,0 +1,64 @@
+import { missingCheck } from "./missing.js"
+import { syncCheck } from "./sync.js"
+import {
+  CheckDefinition,
+  CheckName,
+  CheckRunOptions,
+  CheckSpecificOption,
+  checkSpecificOptions,
+} from "./types.js"
+
+const registeredChecks = [
+  syncCheck,
+  missingCheck,
+] as const satisfies readonly CheckDefinition[]
+
+export const checkDefinitionsByName: Record<CheckName, CheckDefinition> =
+  Object.fromEntries(
+    registeredChecks.map((check) => [check.name, check]),
+  ) as Record<CheckName, CheckDefinition>
+
+export function getRegisteredChecks(): readonly CheckDefinition[] {
+  return registeredChecks
+}
+
+function getSupportedOptions(check: CheckDefinition) {
+  return check.cli.options.map((option) => option.name)
+}
+
+function findSupportedCheck(option: CheckSpecificOption): CheckName {
+  const supportedCheck = registeredChecks.find((check) =>
+    getSupportedOptions(check).includes(option),
+  )?.name
+
+  if (!supportedCheck) {
+    throw new Error(`Unsupported check option \`${option}\`.`)
+  }
+
+  return supportedCheck
+}
+
+export function validateSupportedOptions(
+  check: CheckDefinition,
+  options: CheckRunOptions,
+) {
+  checkSpecificOptions.forEach((option) => {
+    if (!options[option] || getSupportedOptions(check).includes(option)) {
+      return
+    }
+
+    const supportedCheck = findSupportedCheck(option)
+
+    throw new Error(
+      `Option \`--${option}\` can only be used with the \`${supportedCheck}\` check.`,
+    )
+  })
+}
+
+export function getCheck(inputCheck: string): CheckDefinition {
+  if (!(inputCheck in checkDefinitionsByName)) {
+    throw new Error(`Unknown check ${inputCheck}.`)
+  }
+
+  return checkDefinitionsByName[inputCheck as CheckName]
+}

--- a/packages/cli/src/api/check/missing.ts
+++ b/packages/cli/src/api/check/missing.ts
@@ -1,0 +1,65 @@
+import {
+  createMissingTranslationFinding,
+  getCatalogTranslationsWithMissing,
+  MissingTranslationFinding,
+} from "../catalog/translations.js"
+import { Catalog } from "../catalog.js"
+import { runBounded } from "../runBounded.js"
+import { CheckContext, CheckDefinition } from "./types.js"
+
+export async function getMissingTranslationFindings(
+  catalog: Catalog,
+  locale: string,
+): Promise<MissingTranslationFinding[]> {
+  if (locale === catalog.config.pseudoLocale) {
+    return []
+  }
+
+  const { missing } = await getCatalogTranslationsWithMissing(catalog, locale)
+
+  return missing.map((entry) =>
+    createMissingTranslationFinding(catalog, locale, entry),
+  )
+}
+
+export const missingCheck: CheckDefinition = {
+  name: "missing",
+  description:
+    "Verify that locale catalogs contain translations for every extracted message before fallbackLocales are applied.",
+  cli: {
+    options: [],
+    examples: [
+      {
+        description: "Check for missing translations",
+        command: "check missing",
+      },
+      {
+        description: "Check missing translations verbosely for a locale",
+        command: "check missing --locale pl --verbose",
+      },
+    ],
+  },
+  async run(ctx: CheckContext) {
+    const tasks = ctx.locales.flatMap((locale) =>
+      ctx.catalogs.map((catalog) => ({ locale, catalog })),
+    )
+    const findings = (
+      await runBounded(
+        tasks,
+        ctx.workersOptions.poolSize,
+        async ({ locale, catalog }) =>
+          getMissingTranslationFindings(catalog, locale),
+      )
+    ).flat()
+
+    return {
+      name: "missing",
+      passed: findings.length === 0,
+      findings,
+      summary:
+        findings.length === 0
+          ? "No missing translations found."
+          : `Found ${findings.length} missing translation(s).`,
+    }
+  },
+}

--- a/packages/cli/src/api/check/sync.ts
+++ b/packages/cli/src/api/check/sync.ts
@@ -1,0 +1,132 @@
+import nodepath from "path"
+import normalizePath from "normalize-path"
+import { Catalog, cleanObsolete, order } from "../catalog.js"
+import { runBounded } from "../runBounded.js"
+import { createExtractWorkerPool, ExtractWorkerPool } from "../workerPools.js"
+import { readFile } from "../utils.js"
+import {
+  CatalogOutOfSyncFinding,
+  ExtractFailedFinding,
+  CheckDefinition,
+  CheckContext,
+} from "./types.js"
+
+async function getCatalogSyncFindings(
+  catalog: Catalog,
+  ctx: CheckContext,
+  workerPool?: ExtractWorkerPool,
+): Promise<Array<CatalogOutOfSyncFinding | ExtractFailedFinding>> {
+  const nextCatalog = await catalog.collect({ workerPool })
+
+  if (!nextCatalog) {
+    return [
+      {
+        code: "extract_failed",
+        message: `Failed to extract messages for catalog ${catalog.path}`,
+        catalogPath: normalizePath(
+          nodepath.relative(ctx.config.rootDir, catalog.path),
+        ),
+      },
+    ]
+  }
+
+  const prevCatalogs = await catalog.readAll(ctx.locales)
+  const mergedCatalogs = catalog.merge(prevCatalogs, nextCatalog, {
+    overwrite: ctx.overwrite,
+  })
+  const findings = await runBounded(
+    ctx.locales,
+    ctx.workersOptions.poolSize,
+    async (locale): Promise<CatalogOutOfSyncFinding | undefined> => {
+      const filename = catalog.getFilename(locale)
+      const catalogPath = normalizePath(
+        nodepath.relative(ctx.config.rootDir, filename),
+      )
+      let nextLocaleCatalog = mergedCatalogs[locale]!
+
+      if (ctx.clean) {
+        nextLocaleCatalog = cleanObsolete(nextLocaleCatalog)
+      }
+
+      const existing = await readFile(filename)
+      const expected = await catalog.format.serialize(
+        filename,
+        order(ctx.config.orderBy, nextLocaleCatalog),
+        locale,
+        existing,
+      )
+
+      if (existing === expected) {
+        return undefined
+      }
+
+      return {
+        code: "catalog_out_of_sync",
+        message: existing
+          ? `Catalog ${catalogPath} is out of sync with extract output`
+          : `Catalog ${catalogPath} is missing and would be created by extract`,
+        locale,
+        catalogPath,
+      }
+    },
+  )
+
+  return findings.filter(
+    (finding): finding is CatalogOutOfSyncFinding => finding !== undefined,
+  )
+}
+
+export const syncCheck: CheckDefinition = {
+  name: "sync",
+  description:
+    "Verify that locale catalogs are already synchronized with what lingui extract would write.",
+  cli: {
+    options: [
+      {
+        name: "clean",
+        description: "Mirror extract --clean behavior when running sync check",
+      },
+      {
+        name: "overwrite",
+        description:
+          "Mirror extract --overwrite behavior when running sync check",
+      },
+    ],
+    examples: [
+      {
+        description: "Check that catalogs are in sync with extract output",
+        command: "check sync",
+      },
+    ],
+  },
+  async run(ctx: CheckContext) {
+    let workerPool: ExtractWorkerPool | undefined
+    const findings: Array<CatalogOutOfSyncFinding | ExtractFailedFinding> = []
+
+    if (ctx.workersOptions.poolSize) {
+      workerPool = createExtractWorkerPool(ctx.workersOptions)
+    }
+
+    try {
+      for (const catalog of ctx.catalogs) {
+        findings.push(
+          ...(await getCatalogSyncFindings(catalog, ctx, workerPool)),
+        )
+      }
+    } finally {
+      if (workerPool) {
+        await workerPool.destroy()
+      }
+    }
+
+    return {
+      name: "sync",
+      passed: findings.length === 0,
+      findings,
+      summary:
+        findings.length === 0
+          ? "Catalogs are in sync with extract output."
+          : `Found ${findings.length} out-of-sync catalog file(s).`,
+    }
+  },
+}

--- a/packages/cli/src/api/check/types.ts
+++ b/packages/cli/src/api/check/types.ts
@@ -1,0 +1,66 @@
+import { LinguiConfigNormalized } from "@lingui/conf"
+import { Catalog } from "../catalog.js"
+import { MissingTranslationFinding } from "../catalog/translations.js"
+import { CheckFindingBase } from "../findings.js"
+import { WorkersOptions } from "../resolveWorkersOptions.js"
+
+export type CheckName = "sync" | "missing"
+export const checkSpecificOptions = ["clean", "overwrite"] as const
+export type CheckSpecificOption = (typeof checkSpecificOptions)[number]
+
+export type CheckCliExample = {
+  description: string
+  command: string
+}
+
+export type CheckCliOptionDefinition = {
+  name: CheckSpecificOption
+  description: string
+}
+
+export type CatalogOutOfSyncFinding = CheckFindingBase & {
+  code: "catalog_out_of_sync"
+  locale: string
+}
+
+export type ExtractFailedFinding = CheckFindingBase & {
+  code: "extract_failed"
+}
+
+export type CheckFinding =
+  | MissingTranslationFinding
+  | CatalogOutOfSyncFinding
+  | ExtractFailedFinding
+
+export type CheckResult = {
+  name: CheckName
+  passed: boolean
+  findings: CheckFinding[]
+  summary: string
+}
+
+export type CheckContext = {
+  config: LinguiConfigNormalized
+  catalogs: Catalog[]
+  locales: string[]
+  workersOptions: WorkersOptions
+  clean: boolean
+  overwrite: boolean
+}
+
+export type CheckRunOptions = {
+  locale?: string[]
+  workersOptions: WorkersOptions
+  clean?: boolean
+  overwrite?: boolean
+}
+
+export type CheckDefinition = {
+  name: CheckName
+  description: string
+  cli: {
+    options: readonly CheckCliOptionDefinition[]
+    examples: readonly CheckCliExample[]
+  }
+  run: (ctx: CheckContext) => Promise<CheckResult>
+}

--- a/packages/cli/src/api/compile/compileLocale.ts
+++ b/packages/cli/src/api/compile/compileLocale.ts
@@ -9,8 +9,11 @@ import { createCompiledCatalog } from "../compile.js"
 import normalizePath from "normalize-path"
 import nodepath from "path"
 import { createCompilationErrorMessage } from "../messages.js"
-import { getTranslationsForCatalog } from "../catalog/getTranslationsForCatalog.js"
 import { Logger } from "../logger.js"
+import {
+  createMissingTranslationFinding,
+  getCatalogTranslationsWithMissing,
+} from "../catalog/translations.js"
 
 export async function compileLocale(
   catalogs: Catalog[],
@@ -24,11 +27,7 @@ export async function compileLocale(
 
   for (const catalog of catalogs) {
     const { messages, missing: missingMessages } =
-      await getTranslationsForCatalog(catalog, locale, {
-        fallbackLocales: config.fallbackLocales,
-        sourceLocale: config.sourceLocale,
-        missingBehavior: "catalog",
-      })
+      await getCatalogTranslationsWithMissing(catalog, locale)
 
     if (
       !options.allowEmpty &&
@@ -45,12 +44,12 @@ export async function compileLocale(
       if (options.verbose) {
         logger.error(styleText("red", "Missing translations:"))
         missingMessages.forEach((missing) => {
-          const source =
-            missing.source || missing.source === missing.id
-              ? `: (${missing.source})`
-              : ""
-
-          logger.error(`${missing.id}${source}`)
+          const finding = createMissingTranslationFinding(
+            catalog,
+            locale,
+            missing,
+          )
+          logger.error(`${finding.catalogPath}: ${finding.message}`)
         })
       } else {
         logger.error(

--- a/packages/cli/src/api/findings.ts
+++ b/packages/cli/src/api/findings.ts
@@ -1,0 +1,4 @@
+export type CheckFindingBase = {
+  catalogPath: string
+  message: string
+}

--- a/packages/cli/src/api/formats/formatterWrapper.test.ts
+++ b/packages/cli/src/api/formats/formatterWrapper.test.ts
@@ -113,6 +113,38 @@ describe("FormatterWrapper", () => {
   })
 
   describe("write", () => {
+    it("should serialize catalog without writing to FS", async () => {
+      const format = new FormatterWrapper(
+        {
+          serialize: (catalog) => JSON.stringify(catalog),
+          parse: () => ({}),
+          catalogExtension: ".po",
+          templateExtension: ".pot",
+        },
+        "en",
+      )
+
+      mockFs({
+        "messages.json": `{"existing":{"translation":"Existing message"}}`,
+      })
+
+      const content = await format.serialize(
+        "messages.json",
+        {
+          static: {
+            translation: "Static message",
+          },
+        },
+        "en",
+      )
+
+      mockFs.restore()
+
+      expect(content).toMatchInlineSnapshot(
+        `{"static":{"translation":"Static message"}}`,
+      )
+    })
+
     it("should write to FS and serialize catalog using provided formatter", async () => {
       const format = new FormatterWrapper(
         {

--- a/packages/cli/src/api/formats/formatterWrapper.ts
+++ b/packages/cli/src/api/formats/formatterWrapper.ts
@@ -1,5 +1,5 @@
 import { CatalogFormatter, CatalogType } from "@lingui/conf"
-import { readFile, writeFileIfChanged } from "../utils.js"
+import { readFile, writeFile } from "../utils.js"
 import { RethrownError } from "../rethrownError.js"
 
 export class FormatterWrapper {
@@ -16,19 +16,31 @@ export class FormatterWrapper {
     return this.f.templateExtension || this.f.catalogExtension
   }
 
+  async serialize(
+    filename: string,
+    catalog: CatalogType,
+    locale?: string,
+    existing?: string,
+  ): Promise<string> {
+    return await this.f.serialize(catalog, {
+      locale,
+      sourceLocale: this.sourceLocale,
+      existing: existing ?? (await readFile(filename)),
+      filename,
+    })
+  }
+
   async write(
     filename: string,
     catalog: CatalogType,
     locale?: string,
   ): Promise<void> {
-    const content = await this.f.serialize(catalog, {
-      locale,
-      sourceLocale: this.sourceLocale,
-      existing: await readFile(filename),
-      filename,
-    })
+    const existing = await readFile(filename)
+    const content = await this.serialize(filename, catalog, locale, existing)
 
-    await writeFileIfChanged(filename, content)
+    if (content !== existing) {
+      await writeFile(filename, content)
+    }
   }
 
   async read(

--- a/packages/cli/src/api/resolveWorkersOptions.test.ts
+++ b/packages/cli/src/api/resolveWorkersOptions.test.ts
@@ -20,6 +20,13 @@ describe("resolveWorkerOptions", () => {
     })
   })
 
+  test("reject non-numeric workers values", () => {
+    setCores(8)
+    expect(() => resolveWorkersOptions({ workers: "foo" })).toThrow(
+      "The `--workers` option must be an integer.",
+    )
+  })
+
   test("workers=1 forces single-threaded", () => {
     setCores(8)
     expect(resolveWorkersOptions({ workers: 1 })).toEqual({

--- a/packages/cli/src/api/resolveWorkersOptions.ts
+++ b/packages/cli/src/api/resolveWorkersOptions.ts
@@ -2,16 +2,37 @@ import * as os from "node:os"
 
 export type WorkersOptions = { poolSize: number }
 
+function parseWorkers(
+  workers: number | string | undefined,
+): number | undefined {
+  if (workers === undefined) {
+    return undefined
+  }
+
+  const parsedWorkers = Number(workers)
+
+  if (!Number.isFinite(parsedWorkers) || !Number.isInteger(parsedWorkers)) {
+    throw new Error("The `--workers` option must be an integer.")
+  }
+
+  return parsedWorkers
+}
+
 export function resolveWorkersOptions(opts: {
   workers?: number | string
 }): WorkersOptions {
   const cores = os.availableParallelism()
+  const workers = parseWorkers(opts.workers)
 
-  if (Number(opts.workers) <= 1 || cores === 1) {
+  if (workers !== undefined && workers <= 1) {
     return { poolSize: 0 }
   }
 
-  if (!opts.workers) {
+  if (cores === 1) {
+    return { poolSize: 0 }
+  }
+
+  if (workers === undefined) {
     if (cores <= 2) {
       return { poolSize: cores } // on tiny machines, use all
     }
@@ -19,5 +40,5 @@ export function resolveWorkersOptions(opts: {
     return { poolSize: Math.min(cores - 1, 8) }
   }
 
-  return { poolSize: Number(opts.workers) }
+  return { poolSize: workers }
 }

--- a/packages/cli/src/api/runBounded.ts
+++ b/packages/cli/src/api/runBounded.ts
@@ -1,0 +1,20 @@
+export async function runBounded<T, R>(
+  items: readonly T[],
+  concurrency: number,
+  worker: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length)
+  const workerCount = Math.min(Math.max(concurrency, 1), items.length)
+  let nextIndex = 0
+
+  const pool = Array.from({ length: workerCount }, async () => {
+    while (nextIndex < items.length) {
+      const currentIndex = nextIndex++
+      results[currentIndex] = await worker(items[currentIndex]!, currentIndex)
+    }
+  })
+
+  await Promise.all(pool)
+
+  return results
+}

--- a/packages/cli/src/lingui-check.ts
+++ b/packages/cli/src/lingui-check.ts
@@ -1,0 +1,202 @@
+import { styleText } from "node:util"
+import { Command } from "commander"
+import ms from "ms"
+
+import { getConfig, LinguiConfigNormalized } from "@lingui/conf"
+import { helpRun } from "./api/help.js"
+import { getCatalogs } from "./api/index.js"
+import {
+  getCheck,
+  getRegisteredChecks,
+  validateSupportedOptions,
+} from "./api/check/index.js"
+import {
+  CheckCliExample,
+  CheckDefinition,
+  CheckName,
+  CheckRunOptions,
+  CheckResult,
+  CheckSpecificOption,
+} from "./api/check/types.js"
+import { resolveWorkersOptions } from "./api/resolveWorkersOptions.js"
+
+type SharedCliArgs = {
+  config?: string
+  locale?: string[]
+  verbose?: boolean
+  workers?: number | string
+}
+
+type CheckSpecificOptions = Partial<Record<CheckSpecificOption, boolean>>
+
+export function renderCheckResult(result: CheckResult, verbose: boolean) {
+  const status = result.passed
+    ? styleText("green", "PASS")
+    : styleText("red", "FAIL")
+  const lines = [`${status} ${result.name}: ${result.summary}`]
+
+  if (verbose) {
+    lines.push(
+      ...result.findings.map(
+        (finding) => `${finding.catalogPath}: ${finding.message}`,
+      ),
+    )
+  }
+
+  return lines
+}
+
+function validateLocales(
+  config: LinguiConfigNormalized,
+  locales: string[] | undefined,
+): string[] {
+  if (!locales?.length) {
+    return config.locales
+  }
+
+  const missingLocale = locales.find(
+    (locale) => !config.locales.includes(locale),
+  )
+
+  if (missingLocale) {
+    throw new Error(
+      `Locale ${styleText("bold", missingLocale)} does not exist.`,
+    )
+  }
+
+  return locales
+}
+
+export async function runCheck(
+  config: LinguiConfigNormalized,
+  check: CheckName,
+  options: CheckRunOptions,
+): Promise<CheckResult> {
+  const checkDefinition = getCheck(check)
+  validateSupportedOptions(checkDefinition, options)
+  const locales = validateLocales(config, options.locale)
+  const catalogs = await getCatalogs(config)
+
+  return await checkDefinition.run({
+    config,
+    catalogs,
+    locales,
+    workersOptions: options.workersOptions,
+    clean: options.clean ?? false,
+    overwrite: options.overwrite ?? false,
+  })
+}
+
+function parseLocales(value: string) {
+  return value
+    .split(",")
+    .map((locale) => locale.trim())
+    .filter(Boolean)
+}
+
+function addCommonOptions<T extends Command>(command: T): T {
+  return command
+    .option("--config <path>", "Path to the config file")
+    .option(
+      "--locale <locale, [...]>",
+      "Only check the specified locales",
+      parseLocales,
+    )
+    .option(
+      "--workers <n>",
+      "Number of worker threads to use (default: CPU count - 1, capped at 8). Pass `--workers 1` to disable worker threads and run everything in a single process",
+    )
+    .option("--verbose", "Verbose output")
+}
+
+function renderHelpExamples(examples: readonly CheckCliExample[]) {
+  if (!examples.length) {
+    return
+  }
+
+  console.log("\n  Examples:\n")
+  examples.forEach((example, index) => {
+    console.log(`    # ${example.description}`)
+    console.log(`    $ ${helpRun(example.command)}`)
+
+    if (index < examples.length - 1) {
+      console.log("")
+    }
+  })
+}
+
+async function runCliCommand(
+  check: CheckName,
+  options: SharedCliArgs & CheckSpecificOptions,
+) {
+  const startTime = Date.now()
+  const config = getConfig({ configPath: options.config })
+  const verbose = options.verbose ?? false
+
+  console.log("Checking message catalogs…")
+
+  const result = await runCheck(config, check, {
+    locale: options.locale,
+    workersOptions: resolveWorkersOptions(options),
+    clean: options.clean ?? false,
+    overwrite: options.overwrite ?? false,
+  })
+
+  const output = result.passed ? console.log : console.error
+  renderCheckResult(result, verbose).forEach((line) => {
+    output(line)
+  })
+
+  console.log(`Done in ${ms(Date.now() - startTime)}`)
+
+  return result.passed
+}
+
+function registerCheckCommand(checkProgram: Command, check: CheckDefinition) {
+  const command = addCommonOptions(
+    checkProgram.command(check.name).description(check.description),
+  )
+
+  check.cli.options.forEach((option) => {
+    command.option(`--${option.name}`, option.description)
+  })
+
+  command
+    .on("--help", function () {
+      renderHelpExamples(check.cli.examples)
+    })
+    .action(async (options: SharedCliArgs & CheckSpecificOptions) => {
+      if (!(await runCliCommand(check.name, options))) {
+        process.exitCode = 1
+      }
+    })
+}
+
+export function createProgram() {
+  const checkProgram = new Command()
+    .name("lingui check")
+    .description("Check message catalogs.")
+    .action(() => {
+      checkProgram.help({ error: true })
+    })
+    .on("--help", function () {
+      renderHelpExamples(
+        getRegisteredChecks().flatMap((check) => check.cli.examples),
+      )
+    })
+
+  getRegisteredChecks().forEach((check) => {
+    registerCheckCommand(checkProgram, check)
+  })
+
+  return checkProgram
+}
+
+if (import.meta.main) {
+  createProgram()
+    .parseAsync(process.argv)
+    .catch((error) => {
+      console.error((error as Error).message)
+      process.exit(1)
+    })
+}

--- a/packages/cli/src/lingui.ts
+++ b/packages/cli/src/lingui.ts
@@ -19,5 +19,6 @@ program
     "extract-template",
     "Extracts messages from source files to a .pot template",
   )
+  .command("check", "Checks message catalogs")
   .command("compile", "Compile message catalogs")
   .parse(process.argv)

--- a/packages/cli/src/test/__snapshots__/compile.test.ts.snap
+++ b/packages/cli/src/test/__snapshots__/compile.test.ts.snap
@@ -23,8 +23,8 @@ exports[`CLI Command: Compile > allowEmpty = false > Should show missing message
 en ⇒ en.js
 Error: Failed to compile catalog for locale pl!
 Missing translations:
-mY42CM: (Hello World)
-2ZeN02: (Test String)
+pl.po: mY42CM: (Hello World)
+pl.po: 2ZeN02: (Test String)
 
 `;
 

--- a/packages/cli/src/test/check-cli.test.ts
+++ b/packages/cli/src/test/check-cli.test.ts
@@ -1,0 +1,49 @@
+import { createProgram } from "../lingui-check.js"
+import { getRegisteredChecks } from "../api/check/index.js"
+import { mockConsole } from "@lingui/test-utils"
+
+describe("CLI: check", () => {
+  it("Should require a check subcommand in CLI mode", async () => {
+    const program = createProgram()
+    program.exitOverride()
+    program.configureOutput({
+      writeOut: () => {},
+      writeErr: () => {},
+    })
+
+    await mockConsole(async () => {
+      await expect(
+        program.parseAsync(["node", "lingui-check"]),
+      ).rejects.toMatchObject({
+        code: "commander.help",
+        exitCode: 1,
+      })
+    })
+  })
+
+  it("Should register check subcommands from the registry", () => {
+    const program = createProgram()
+    const commandNames = program.commands.map((command) => command.name())
+
+    expect(commandNames).toEqual(
+      getRegisteredChecks().map((check) => check.name),
+    )
+
+    const syncCommand = program.commands.find(
+      (command) => command.name() === "sync",
+    )
+    const missingCommand = program.commands.find(
+      (command) => command.name() === "missing",
+    )
+
+    expect(syncCommand?.options.map((option) => option.long)).toContain(
+      "--clean",
+    )
+    expect(syncCommand?.options.map((option) => option.long)).toContain(
+      "--overwrite",
+    )
+    expect(missingCommand?.options.map((option) => option.long)).not.toContain(
+      "--clean",
+    )
+  })
+})

--- a/packages/cli/src/test/check-missing.test.ts
+++ b/packages/cli/src/test/check-missing.test.ts
@@ -1,0 +1,154 @@
+import { renderCheckResult, runCheck } from "../lingui-check.js"
+import { makeConfig } from "@lingui/conf"
+import { createFixtures, readFsToListing } from "../tests.js"
+import {
+  extractCatalogs,
+  getTestConfig,
+  replaceInFile,
+  workersOptions,
+} from "./checkTestUtils.js"
+
+describe("Check: missing", () => {
+  it("Should fail when a locale catalog has missing translations", async () => {
+    const rootDir = await createFixtures({
+      "src/app.ts": `
+import { t } from "@lingui/core/macro"
+
+t\`Hello World\`
+        `,
+      "locales/en/messages.po": `
+msgid "Hello World"
+msgstr "Hello World"
+        `,
+      "locales/pl/messages.po": `
+msgid "Hello World"
+msgstr ""
+        `,
+    })
+
+    const config = getTestConfig(rootDir)
+    const before = readFsToListing(rootDir)
+    const result = await runCheck(config, "missing", {
+      workersOptions,
+    })
+    const after = readFsToListing(rootDir)
+    const rendered = renderCheckResult(result, false).join("\n")
+
+    expect(result.passed).toBeFalsy()
+    expect(after).toEqual(before)
+    expect(rendered).toContain("FAIL missing")
+  })
+
+  it("Should render missing translation details in verbose mode", async () => {
+    const rootDir = await createFixtures({
+      "src/app.ts": `
+import { t } from "@lingui/core/macro"
+
+t\`Hello World\`
+        `,
+      "locales/en/messages.po": `
+msgid "Hello World"
+msgstr "Hello World"
+        `,
+      "locales/pl/messages.po": `
+msgid "Hello World"
+msgstr ""
+        `,
+    })
+
+    const config = getTestConfig(rootDir)
+    const result = await runCheck(config, "missing", {
+      workersOptions,
+    })
+    const rendered = renderCheckResult(result, true).join("\n")
+
+    expect(result.passed).toBeFalsy()
+    expect(rendered).toContain("locales/pl/messages.po")
+    expect(rendered).toContain("Hello World")
+  })
+
+  it("Should fail even when fallbackLocales can resolve missing translations", async () => {
+    const rootDir = await createFixtures({
+      "locales/en-US/messages.po": `
+msgid "Hello World"
+msgstr "Hello World"
+        `,
+      "locales/en-GB/messages.po": `
+msgid "Hello World"
+msgstr ""
+        `,
+    })
+
+    const config = makeConfig({
+      locales: ["en-US", "en-GB"],
+      sourceLocale: "en-US",
+      fallbackLocales: {
+        default: "en-US",
+      },
+      rootDir,
+      catalogs: [
+        {
+          path: "<rootDir>/locales/{locale}/messages",
+          include: ["<rootDir>/src"],
+          exclude: [],
+        },
+      ],
+    })
+
+    const result = await runCheck(config, "missing", {
+      workersOptions,
+    })
+    const rendered = renderCheckResult(result, false).join("\n")
+
+    expect(result.passed).toBeFalsy()
+    expect(rendered).toContain("FAIL missing")
+  })
+
+  it("Should skip pseudo locale", async () => {
+    const rootDir = await createFixtures({
+      "locales/en/messages.po": `
+msgid "Hello World"
+msgstr "Hello World"
+        `,
+      "locales/pl/messages.po": `
+msgid "Hello World"
+msgstr ""
+        `,
+    })
+
+    const config = getTestConfig(rootDir, {
+      pseudoLocale: "pl",
+    })
+
+    const result = await runCheck(config, "missing", {
+      workersOptions,
+    })
+
+    expect(result.passed).toBeTruthy()
+  })
+
+  it("Should respect locale filter", async () => {
+    const rootDir = await createFixtures({
+      "src/app.ts": `
+import { t } from "@lingui/core/macro"
+
+t\`Hello World\`
+        `,
+    })
+
+    const config = getTestConfig(rootDir)
+    await extractCatalogs(config)
+    await replaceInFile(
+      `${rootDir}/locales/pl/messages.po`,
+      'msgid "Hello World"\nmsgstr ""',
+      'msgid "Hello World"\nmsgstr "Czesc swiecie"',
+    )
+
+    const result = await runCheck(config, "missing", {
+      locale: ["pl"],
+      workersOptions,
+    })
+
+    expect(result.passed).toBeTruthy()
+  })
+})

--- a/packages/cli/src/test/check-registry.test.ts
+++ b/packages/cli/src/test/check-registry.test.ts
@@ -1,0 +1,60 @@
+import {
+  getCheck,
+  getRegisteredChecks,
+  validateSupportedOptions,
+} from "../api/check/index.js"
+import { runCheck } from "../lingui-check.js"
+import { createFixtures } from "../tests.js"
+import { getTestConfig, workersOptions } from "./checkTestUtils.js"
+
+describe("Check Registry", () => {
+  it("Should reject unknown checks during direct resolution", () => {
+    expect(() => getCheck("unknown")).toThrow("Unknown check")
+  })
+
+  it("Should expose all registered checks", () => {
+    expect(getRegisteredChecks().map((check) => check.name)).toEqual([
+      "sync",
+      "missing",
+    ])
+  })
+
+  it("Should reject clean with the missing check only", () => {
+    expect(() =>
+      validateSupportedOptions(getCheck("missing"), {
+        clean: true,
+        workersOptions,
+      }),
+    ).toThrow("Option `--clean` can only be used with the `sync` check.")
+  })
+
+  it("Should reject overwrite with the missing check only", () => {
+    expect(() =>
+      validateSupportedOptions(getCheck("missing"), {
+        overwrite: true,
+        workersOptions,
+      }),
+    ).toThrow("Option `--overwrite` can only be used with the `sync` check.")
+  })
+
+  it("Should reject unsupported options through runCheck", async () => {
+    const rootDir = await createFixtures({
+      "src/app.ts": `
+import { t } from "@lingui/core/macro"
+
+t\`Hello World\`
+        `,
+    })
+
+    const config = getTestConfig(rootDir)
+
+    await expect(
+      runCheck(config, "missing", {
+        clean: true,
+        workersOptions,
+      }),
+    ).rejects.toThrow(
+      "Option `--clean` can only be used with the `sync` check.",
+    )
+  })
+})

--- a/packages/cli/src/test/check-sync.test.ts
+++ b/packages/cli/src/test/check-sync.test.ts
@@ -1,0 +1,313 @@
+import fs from "fs"
+import { formatter as poFormatter } from "@lingui/format-po"
+import { renderCheckResult, runCheck } from "../lingui-check.js"
+import { createFixtures, readFsToListing } from "../tests.js"
+import {
+  extractCatalogs,
+  getTestConfig,
+  replaceInFile,
+  workersOptions,
+} from "./checkTestUtils.js"
+
+describe("Check: sync", () => {
+  it("Should pass when catalogs are in sync with extract output", async () => {
+    const rootDir = await createFixtures({
+      "src/app.ts": `
+import { t } from "@lingui/core/macro"
+
+t\`Hello World\`
+        `,
+    })
+
+    const config = getTestConfig(rootDir)
+    await extractCatalogs(config)
+    const before = readFsToListing(rootDir)
+    const result = await runCheck(config, "sync", {
+      workersOptions,
+    })
+    const after = readFsToListing(rootDir)
+
+    expect(result.passed).toBeTruthy()
+    expect(after).toEqual(before)
+  })
+
+  it("Should fail when extract would add new messages", async () => {
+    const rootDir = await createFixtures({
+      "src/app.ts": `
+import { t } from "@lingui/core/macro"
+
+t\`Hello World\`
+        `,
+    })
+
+    const config = getTestConfig(rootDir)
+    await extractCatalogs(config)
+    await fs.promises.writeFile(
+      `${rootDir}/src/app.ts`,
+      `
+import { t } from "@lingui/core/macro"
+
+t\`Hello World\`
+t\`New Message\`
+        `,
+      "utf-8",
+    )
+    const before = readFsToListing(rootDir)
+    const result = await runCheck(config, "sync", {
+      workersOptions,
+    })
+    const after = readFsToListing(rootDir)
+    const rendered = renderCheckResult(result, true).join("\n")
+
+    expect(result.passed).toBeFalsy()
+    expect(after).toEqual(before)
+    expect(rendered).toContain("FAIL sync")
+    expect(rendered).toContain("locales/en/messages.po")
+    expect(rendered).toContain("out-of-sync")
+  })
+
+  it("Should fail on source locale drift when overwrite = true", async () => {
+    const rootDir = await createFixtures({
+      "src/app.ts": `
+import { t } from "@lingui/core/macro"
+
+t({ id: "msg.hello", message: "Initial source message" })
+        `,
+    })
+
+    const config = getTestConfig(rootDir)
+    await extractCatalogs(config)
+    await replaceInFile(
+      `${rootDir}/locales/en/messages.po`,
+      'msgstr "Initial source message"',
+      'msgstr "Custom source translation"',
+    )
+    await fs.promises.writeFile(
+      `${rootDir}/src/app.ts`,
+      `
+import { t } from "@lingui/core/macro"
+
+t({ id: "msg.hello", message: "Updated source message" })
+        `,
+      "utf-8",
+    )
+
+    const result = await runCheck(config, "sync", {
+      overwrite: true,
+      workersOptions,
+    })
+    const rendered = renderCheckResult(result, false).join("\n")
+
+    expect(result.passed).toBeFalsy()
+    expect(rendered).toContain("FAIL sync")
+  })
+
+  it("Should not require source locale updates when overwrite = false", async () => {
+    const rootDir = await createFixtures({
+      "src/app.ts": `
+import { t } from "@lingui/core/macro"
+
+t({ id: "msg.hello", message: "Initial source message" })
+        `,
+    })
+
+    const config = getTestConfig(rootDir)
+    await extractCatalogs(config)
+    await replaceInFile(
+      `${rootDir}/locales/en/messages.po`,
+      'msgstr "Initial source message"',
+      'msgstr "Custom source translation"',
+    )
+    await fs.promises.writeFile(
+      `${rootDir}/src/app.ts`,
+      `
+import { t } from "@lingui/core/macro"
+
+t({ id: "msg.hello", message: "Updated source message" })
+        `,
+      "utf-8",
+    )
+
+    const result = await runCheck(config, "sync", {
+      overwrite: false,
+      workersOptions,
+    })
+
+    expect(result.passed).toBeTruthy()
+  })
+
+  it("Should respect clean semantics", async () => {
+    const rootDir = await createFixtures({
+      "src/app.ts": `
+import { t } from "@lingui/core/macro"
+
+t\`Hello World\`
+t\`Obsolete Message\`
+        `,
+    })
+
+    const config = getTestConfig(rootDir)
+    await extractCatalogs(config)
+    await fs.promises.writeFile(
+      `${rootDir}/src/app.ts`,
+      `
+import { t } from "@lingui/core/macro"
+
+t\`Hello World\`
+        `,
+      "utf-8",
+    )
+    await extractCatalogs(config)
+
+    const syncResult = await runCheck(config, "sync", {
+      workersOptions,
+    })
+
+    expect(syncResult.passed).toBeTruthy()
+
+    const cleanResult = await runCheck(config, "sync", {
+      clean: true,
+      workersOptions,
+    })
+    const rendered = renderCheckResult(cleanResult, false).join("\n")
+
+    expect(cleanResult.passed).toBeFalsy()
+    expect(rendered).toContain("FAIL sync")
+  })
+
+  it("Should respect locale filter", async () => {
+    const rootDir = await createFixtures({
+      "src/app.ts": `
+import { t } from "@lingui/core/macro"
+
+t\`Hello World\`
+t\`New Message\`
+        `,
+    })
+
+    const config = getTestConfig(rootDir)
+    await extractCatalogs(config)
+    await replaceInFile(
+      `${rootDir}/locales/pl/messages.po`,
+      '\nmsgid "New Message"\nmsgstr ""\n',
+      "\n",
+    )
+
+    const result = await runCheck(config, "sync", {
+      locale: ["en"],
+      workersOptions,
+    })
+
+    expect(result.passed).toBeTruthy()
+  })
+
+  it("Should ignore unreadable catalogs outside the selected locale filter", async () => {
+    const rootDir = await createFixtures({
+      "src/app.ts": `
+import { t } from "@lingui/core/macro"
+
+t\`Hello World\`
+        `,
+    })
+
+    const config = getTestConfig(rootDir)
+    await extractCatalogs(config)
+    await fs.promises.writeFile(
+      `${rootDir}/locales/pl/messages.po`,
+      'msgid "broken"\nmsgstr "\n',
+      "utf-8",
+    )
+
+    const result = await runCheck(config, "sync", {
+      locale: ["en"],
+      workersOptions,
+    })
+
+    expect(result.passed).toBeTruthy()
+  })
+
+  it("Should fail when formatter lineNumbers config changes", async () => {
+    const rootDir = await createFixtures({
+      "src/app.ts": `
+import { t } from "@lingui/core/macro"
+
+t\`Hello World\`
+        `,
+    })
+
+    const config = getTestConfig(rootDir)
+    await extractCatalogs(config)
+
+    const configWithDifferentFormat = getTestConfig(rootDir, {
+      format: poFormatter({ lineNumbers: false }),
+    })
+
+    const result = await runCheck(configWithDifferentFormat, "sync", {
+      workersOptions,
+    })
+    const rendered = renderCheckResult(result, false).join("\n")
+
+    expect(result.passed).toBeFalsy()
+    expect(rendered).toContain("FAIL sync")
+  })
+
+  it("Should fail when formatter custom headers config changes", async () => {
+    const rootDir = await createFixtures({
+      "src/app.ts": `
+import { t } from "@lingui/core/macro"
+
+t\`Hello World\`
+        `,
+    })
+
+    const config = getTestConfig(rootDir)
+    await extractCatalogs(config)
+
+    const configWithDifferentFormat = getTestConfig(rootDir, {
+      format: poFormatter({
+        customHeaderAttributes: {
+          "X-Custom-Attribute": "custom-value",
+        },
+      }),
+    })
+
+    const result = await runCheck(configWithDifferentFormat, "sync", {
+      workersOptions,
+    })
+    const rendered = renderCheckResult(result, false).join("\n")
+
+    expect(result.passed).toBeFalsy()
+    expect(rendered).toContain("FAIL sync")
+  })
+
+  it("Should render sync findings without writing to console", async () => {
+    const rootDir = await createFixtures({
+      "src/app.ts": `
+import { t } from "@lingui/core/macro"
+
+t\`Hello World\`
+        `,
+    })
+
+    const config = getTestConfig(rootDir)
+    await extractCatalogs(config)
+    await fs.promises.writeFile(
+      `${rootDir}/src/app.ts`,
+      `
+import { t } from "@lingui/core/macro"
+
+t\`Hello World\`
+t\`New Message\`
+        `,
+      "utf-8",
+    )
+
+    const result = await runCheck(config, "sync", {
+      workersOptions,
+    })
+    const rendered = renderCheckResult(result, true)
+
+    expect(rendered[0]).toContain("FAIL sync")
+    expect(rendered[1]).toContain("locales/en/messages.po")
+  })
+})

--- a/packages/cli/src/test/checkTestUtils.ts
+++ b/packages/cli/src/test/checkTestUtils.ts
@@ -1,0 +1,57 @@
+import fs from "fs"
+import { LinguiConfig, makeConfig } from "@lingui/conf"
+import { mockConsole } from "@lingui/test-utils"
+import extractCommand from "../lingui-extract.js"
+
+export function getTestConfig(
+  rootDir: string,
+  config: Partial<LinguiConfig> = {},
+) {
+  return makeConfig({
+    locales: ["en", "pl"],
+    sourceLocale: "en",
+    rootDir,
+    catalogs: [
+      {
+        path: "<rootDir>/locales/{locale}/messages",
+        include: ["<rootDir>/src"],
+        exclude: [],
+      },
+    ],
+    ...config,
+  })
+}
+
+export const workersOptions = {
+  poolSize: 0,
+}
+
+export async function extractCatalogs(
+  config: ReturnType<typeof getTestConfig>,
+  options: { overwrite?: boolean; clean?: boolean } = {},
+) {
+  await mockConsole(async () => {
+    await extractCommand(config, {
+      verbose: false,
+      clean: options.clean || false,
+      overwrite: options.overwrite || false,
+      workersOptions,
+    })
+  })
+}
+
+export async function replaceInFile(
+  filename: string,
+  searchValue: string,
+  replaceValue: string,
+) {
+  const content = await fs.promises.readFile(filename, "utf-8")
+  if (!content.includes(searchValue)) {
+    throw new Error(`Expected to find "${searchValue}" in ${filename}`)
+  }
+  await fs.promises.writeFile(
+    filename,
+    content.replace(searchValue, replaceValue),
+    "utf-8",
+  )
+}

--- a/packages/cli/test/extract-partial-consistency/expected/en.po
+++ b/packages/cli/test/extract-partial-consistency/expected/en.po
@@ -6,12 +6,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: en\n"
-"Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: \n"
-"Last-Translator: \n"
-"Language-Team: \n"
-"Plural-Forms: \n"
 
 #. js-lingui-explicit-id
 #: fixtures/file-a.ts:11

--- a/packages/cli/test/extractor-experimental-clean/expected/about.page.en.po
+++ b/packages/cli/test/extractor-experimental-clean/expected/about.page.en.po
@@ -6,12 +6,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: en\n"
-"Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: \n"
-"Last-Translator: \n"
-"Language-Team: \n"
-"Plural-Forms: \n"
 
 #: fixtures/pages/about.page.ts:4
 msgid "about page message"

--- a/packages/cli/test/extractor-experimental-clean/expected/about.page.pl.po
+++ b/packages/cli/test/extractor-experimental-clean/expected/about.page.pl.po
@@ -6,12 +6,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: pl\n"
-"Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: \n"
-"Last-Translator: \n"
-"Language-Team: \n"
-"Plural-Forms: \n"
 
 #: fixtures/pages/about.page.ts:4
 msgid "about page message"

--- a/packages/cli/test/extractor-experimental-clean/expected/index.page.en.po
+++ b/packages/cli/test/extractor-experimental-clean/expected/index.page.en.po
@@ -6,12 +6,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: en\n"
-"Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: \n"
-"Last-Translator: \n"
-"Language-Team: \n"
-"Plural-Forms: \n"
 
 #: fixtures/pages/index.page.ts:3
 msgid "index page message"

--- a/packages/cli/test/extractor-experimental-clean/expected/index.page.pl.po
+++ b/packages/cli/test/extractor-experimental-clean/expected/index.page.pl.po
@@ -6,12 +6,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: pl\n"
-"Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: \n"
-"Last-Translator: \n"
-"Language-Team: \n"
-"Plural-Forms: \n"
 
 #: fixtures/pages/index.page.ts:3
 msgid "index page message"

--- a/packages/cli/test/extractor-experimental/expected/about.page.en.po
+++ b/packages/cli/test/extractor-experimental/expected/about.page.en.po
@@ -6,12 +6,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: en\n"
-"Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: \n"
-"Last-Translator: \n"
-"Language-Team: \n"
-"Plural-Forms: \n"
 
 #: fixtures/pages/about.page.ts:5
 msgid "about page message"

--- a/packages/cli/test/extractor-experimental/expected/about.page.pl.po
+++ b/packages/cli/test/extractor-experimental/expected/about.page.pl.po
@@ -6,12 +6,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: pl\n"
-"Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: \n"
-"Last-Translator: \n"
-"Language-Team: \n"
-"Plural-Forms: \n"
 
 #: fixtures/pages/about.page.ts:5
 msgid "about page message"

--- a/packages/cli/test/extractor-experimental/expected/index.page.en.po
+++ b/packages/cli/test/extractor-experimental/expected/index.page.en.po
@@ -6,12 +6,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: en\n"
-"Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: \n"
-"Last-Translator: \n"
-"Language-Team: \n"
-"Plural-Forms: \n"
 
 #: fixtures/pages/index.page.ts:4
 msgid "index page message"

--- a/packages/cli/test/extractor-experimental/expected/index.page.pl.po
+++ b/packages/cli/test/extractor-experimental/expected/index.page.pl.po
@@ -6,12 +6,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: pl\n"
-"Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: \n"
-"Last-Translator: \n"
-"Language-Team: \n"
-"Plural-Forms: \n"
 
 #: fixtures/pages/index.page.ts:4
 msgid "index page message"

--- a/packages/format-po/src/po.test.ts
+++ b/packages/format-po/src/po.test.ts
@@ -542,6 +542,152 @@ describe("pofile format", () => {
     `)
   })
 
+  it("should be idempotent after serializing over an existing file", async () => {
+    const format = createFormatter()
+    const catalog: CatalogType = {}
+
+    const first = await format.serialize(catalog, defaultSerializeCtx)
+    const second = await format.serialize(catalog, {
+      ...defaultSerializeCtx,
+      existing: first,
+    })
+
+    expect(second).toBe(first)
+  })
+
+  it("should preserve existing POT-Creation-Date by default", () => {
+    const format = createFormatter()
+    const catalog: CatalogType = {}
+
+    const actual = format.serialize(catalog, {
+      ...defaultSerializeCtx,
+      existing: `msgid ""
+msgstr ""
+"POT-Creation-Date: 2000-01-01 00:00+0000\\n"
+"MIME-Version: 1.0\\n"
+"Content-Type: text/plain; charset=utf-8\\n"
+"Content-Transfer-Encoding: 8bit\\n"
+"X-Generator: @lingui/cli\\n"
+"Language: en\\n"
+`,
+    })
+
+    expect(actual).toContain(`"POT-Creation-Date: 2000-01-01 00:00+0000\\n"`)
+  })
+
+  it("should preserve header comments when serializing over an existing file", () => {
+    const format = createFormatter()
+    const catalog: CatalogType = {}
+
+    const actual = format.serialize(catalog, {
+      ...defaultSerializeCtx,
+      existing: `# Translator header comment
+#. Extracted header comment
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2000-01-01 00:00+0000\\n"
+"MIME-Version: 1.0\\n"
+"Content-Type: text/plain; charset=utf-8\\n"
+"Content-Transfer-Encoding: 8bit\\n"
+"X-Generator: @lingui/cli\\n"
+"Language: en\\n"
+`,
+    })
+
+    expect(actual).toContain("# Translator header comment")
+    expect(actual).toContain("#. Extracted header comment")
+  })
+
+  it("should override POT-Creation-Date when provided in custom header attributes", () => {
+    const format = createFormatter({
+      customHeaderAttributes: { "POT-Creation-Date": "" },
+    })
+    const catalog: CatalogType = {}
+
+    const actual = format.serialize(catalog, {
+      ...defaultSerializeCtx,
+      existing: `msgid ""
+msgstr ""
+"POT-Creation-Date: 2000-01-01 00:00+0000\\n"
+"MIME-Version: 1.0\\n"
+"Content-Type: text/plain; charset=utf-8\\n"
+"Content-Transfer-Encoding: 8bit\\n"
+"X-Generator: @lingui/cli\\n"
+"Language: en\\n"
+`,
+    })
+
+    expect(actual).toContain(`"POT-Creation-Date: \\n"`)
+  })
+
+  it("should apply custom header attributes when serializing over an existing file", () => {
+    const format = createFormatter({
+      customHeaderAttributes: { "X-Custom-Attribute": "custom-value" },
+    })
+    const catalog: CatalogType = {}
+
+    const actual = format.serialize(catalog, {
+      ...defaultSerializeCtx,
+      existing: `msgid ""
+msgstr ""
+"POT-Creation-Date: 2000-01-01 00:00+0000\\n"
+"MIME-Version: 1.0\\n"
+"Content-Type: text/plain; charset=utf-8\\n"
+"Content-Transfer-Encoding: 8bit\\n"
+"X-Generator: @lingui/cli\\n"
+"Language: en\\n"
+`,
+    })
+
+    expect(actual).toContain(`"X-Custom-Attribute: custom-value\\n"`)
+  })
+
+  it("should drop empty default headers when serializing over an existing file", () => {
+    const format = createFormatter()
+    const catalog: CatalogType = {}
+
+    const actual = format.serialize(catalog, {
+      ...defaultSerializeCtx,
+      existing: `msgid ""
+msgstr ""
+"POT-Creation-Date: 2000-01-01 00:00+0000\\n"
+"MIME-Version: 1.0\\n"
+"Content-Type: text/plain; charset=utf-8\\n"
+"Content-Transfer-Encoding: 8bit\\n"
+"X-Generator: @lingui/cli\\n"
+"Language: en\\n"
+"Project-Id-Version: \\n"
+"Report-Msgid-Bugs-To: \\n"
+"PO-Revision-Date: \\n"
+"Last-Translator: \\n"
+"Language-Team: \\n"
+"Plural-Forms: \\n"
+`,
+    })
+
+    expect(actual).not.toContain(`"Project-Id-Version: \\n"`)
+    expect(actual).not.toContain(`"Plural-Forms: \\n"`)
+  })
+
+  it("should keep lineNumbers disabled when serializing over an existing file", async () => {
+    const format = createFormatter({ origins: true, lineNumbers: false })
+    const catalog: CatalogType = {
+      withOrigin: {
+        translation: "Message with origin",
+        origin: [["src/App.js", 4]],
+      },
+    }
+
+    const existing = await format.serialize(catalog, defaultSerializeCtx)
+    const actual = await format.serialize(catalog, {
+      ...defaultSerializeCtx,
+      existing,
+    })
+
+    expect(actual).toContain(`#: src/App.js`)
+    expect(actual).not.toContain(`#: src/App.js:4`)
+  })
+
   describe("printPlaceholdersInComments", () => {
     it("should print unnamed placeholders as comments", () => {
       const format = createFormatter()

--- a/packages/format-po/src/po.ts
+++ b/packages/format-po/src/po.ts
@@ -106,19 +106,116 @@ function isGeneratedId(id: string, message: MessageType): boolean {
   return id === generateMessageId(message.message!, message.context)
 }
 
-function getCreateHeaders(
+const MANAGED_HEADERS = [
+  "POT-Creation-Date",
+  "MIME-Version",
+  "Content-Type",
+  "Content-Transfer-Encoding",
+  "X-Generator",
+  "Language",
+] as const
+
+const EMPTY_DEFAULT_HEADERS = [
+  "Project-Id-Version",
+  "Report-Msgid-Bugs-To",
+  "PO-Revision-Date",
+  "Last-Translator",
+  "Language-Team",
+  "Plural-Forms",
+] as const
+
+function shouldKeepExistingHeader(
+  key: string,
+  value: string | undefined,
+  customHeaderAttributes: PoFormatterOptions["customHeaderAttributes"],
+) {
+  if (MANAGED_HEADERS.includes(key as (typeof MANAGED_HEADERS)[number])) {
+    return false
+  }
+
+  if (customHeaderAttributes && key in customHeaderAttributes) {
+    return false
+  }
+
+  if (
+    EMPTY_DEFAULT_HEADERS.includes(
+      key as (typeof EMPTY_DEFAULT_HEADERS)[number],
+    ) &&
+    !value
+  ) {
+    return false
+  }
+
+  return true
+}
+
+function getNormalizedHeaders(
   language: string | undefined,
   customHeaderAttributes: PoFormatterOptions["customHeaderAttributes"],
+  existingHeaders: PO["headers"] | undefined,
 ): PO["headers"] {
-  return {
-    "POT-Creation-Date": formatPotCreationDate(new Date()),
-    "MIME-Version": "1.0",
-    "Content-Type": "text/plain; charset=utf-8",
-    "Content-Transfer-Encoding": "8bit",
-    "X-Generator": "@lingui/cli",
-    ...(language ? { Language: language } : {}),
-    ...(customHeaderAttributes ?? {}),
+  const nextHeaders: PO["headers"] = {}
+
+  if (existingHeaders) {
+    Object.entries(existingHeaders).forEach(([key, value]) => {
+      if (shouldKeepExistingHeader(key, value, customHeaderAttributes)) {
+        nextHeaders[key] = value
+      }
+    })
   }
+
+  nextHeaders["POT-Creation-Date"] =
+    customHeaderAttributes?.["POT-Creation-Date"] ??
+    existingHeaders?.["POT-Creation-Date"] ??
+    formatPotCreationDate(new Date())
+  nextHeaders["MIME-Version"] = "1.0"
+  nextHeaders["Content-Type"] = "text/plain; charset=utf-8"
+  nextHeaders["Content-Transfer-Encoding"] = "8bit"
+  nextHeaders["X-Generator"] = "@lingui/cli"
+
+  if (language) {
+    nextHeaders.Language = language
+  }
+
+  Object.entries(customHeaderAttributes ?? {}).forEach(([key, value]) => {
+    nextHeaders[key] = value
+  })
+
+  return nextHeaders
+}
+
+function getHeaderOrder(
+  headers: PO["headers"],
+  language: string | undefined,
+  customHeaderAttributes: PoFormatterOptions["customHeaderAttributes"],
+  existingHeaderOrder: string[] | undefined,
+) {
+  const managedOrder = [
+    "POT-Creation-Date",
+    "MIME-Version",
+    "Content-Type",
+    "Content-Transfer-Encoding",
+    "X-Generator",
+    ...(language ? ["Language"] : []),
+    ...Object.keys(customHeaderAttributes ?? {}).filter(
+      (key) =>
+        !MANAGED_HEADERS.includes(key as (typeof MANAGED_HEADERS)[number]),
+    ),
+  ]
+
+  const order = new Set(managedOrder)
+
+  existingHeaderOrder?.forEach((key) => {
+    if (key in headers) {
+      order.add(key)
+    }
+  })
+
+  Object.keys(headers).forEach((key) => {
+    order.add(key)
+  })
+
+  return [...order]
 }
 
 const EXPLICIT_ID_FLAG = "js-lingui-explicit-id"
@@ -285,19 +382,23 @@ export function formatter(options: PoFormatterOptions = {}): CatalogFormatter {
     },
 
     serialize(catalog, ctx): string {
-      let po: PO
+      const existingPo = ctx.existing ? PO.parse(ctx.existing) : undefined
+      const po = new PO()
 
-      if (ctx.existing) {
-        po = PO.parse(ctx.existing)
-      } else {
-        po = new PO()
-        po.headers = getCreateHeaders(
-          ctx.locale,
-          options.customHeaderAttributes,
-        )
-        // accessing private property
-        ;(po as any).headerOrder = Object.keys(po.headers)
-      }
+      po.comments = [...(existingPo?.comments ?? [])]
+      po.extractedComments = [...(existingPo?.extractedComments ?? [])]
+      po.headers = getNormalizedHeaders(
+        ctx.locale,
+        options.customHeaderAttributes,
+        existingPo?.headers,
+      )
+      // accessing private property
+      ;(po as any).headerOrder = getHeaderOrder(
+        po.headers,
+        ctx.locale,
+        options.customHeaderAttributes,
+        existingPo ? (existingPo as any).headerOrder : undefined,
+      )
 
       po.items = serialize(catalog, options, {
         locale: ctx.locale,

--- a/website/docs/ref/cli.md
+++ b/website/docs/ref/cli.md
@@ -1,11 +1,11 @@
 ---
 title: Lingui CLI
-description: Learn how to set up and use Lingui CLI to extract, merge and compile message catalogs
+description: Learn how to set up and use Lingui CLI to extract, check, merge and compile message catalogs
 ---
 
 # Lingui CLI
 
-The `@lingui/cli` tool provides the `lingui` command which allows you to extract messages from source files into message catalogs and compile these catalogs for production use.
+The `@lingui/cli` tool provides the `lingui` command which allows you to extract messages from source files into message catalogs, check them, and compile these catalogs for production use.
 
 ## Installation
 
@@ -279,6 +279,92 @@ The generated file header will look like:
 ```js
 /*your-prefix-here*/ export const messages = JSON.parse("{}");
 ```
+
+### `check`
+
+```shell
+lingui check <command>
+```
+
+The `check` command is a namespace for validation subcommands. Running `lingui check` without a subcommand prints help and exits without running any validation.
+
+These subcommands are useful in CI when you want to fail fast on stale catalogs or missing translations but do not need compilation artifacts yet.
+
+#### `sync`
+
+```shell
+lingui check sync
+    [--locale <locale, [...]>]
+    [--clean]
+    [--overwrite]
+    [--verbose]
+    [--workers]
+```
+
+Checks whether locale catalogs are synchronized with the current source code. This validation mirrors the behavior of `lingui extract` in dry-run mode and fails if extract would create or update any locale catalog file.
+
+This validation checks locale catalogs only. It does not validate `.pot` / template freshness.
+
+#### `missing`
+
+```shell
+lingui check missing
+    [--locale <locale, [...]>]
+    [--verbose]
+    [--workers]
+```
+
+Checks whether locale catalogs have missing translations before `fallbackLocales` are applied. This validation shares the same missing-detection semantics as `lingui compile --strict`, but does not compile catalogs.
+
+#### `sync --locale <locale, [...]>` {#check-sync-locale}
+
+Only check the specified locales when running `lingui check sync`.
+
+#### `sync --clean` {#check-sync-clean}
+
+When running the `sync` validation, mirror `lingui extract --clean`. Obsolete messages are expected to be removed.
+
+#### `sync --overwrite` {#check-sync-overwrite}
+
+When running the `sync` validation, mirror `lingui extract --overwrite`. Source locale translations are expected to be overwritten from source messages.
+
+#### `sync --verbose` {#check-sync-verbose}
+
+Print detailed findings for each failing `sync` validation.
+
+#### `sync --workers` {#check-sync-workers}
+
+Specifies the number of worker threads to use for `lingui check sync`.
+
+Pass `--workers 1` to disable workers and run everything in a single process.
+
+By default, the tool uses a simple heuristic:
+
+- On machines with more than 2 cores → `cpu.count - 1` workers
+- On 2-core machines → all cores
+
+Use the `--verbose` flag to see the actual pool size.
+
+#### `missing --locale <locale, [...]>` {#check-missing-locale}
+
+Only check the specified locales when running `lingui check missing`.
+
+#### `missing --verbose` {#check-missing-verbose}
+
+Print detailed findings for each failing `missing` validation.
+
+#### `missing --workers` {#check-missing-workers}
+
+Specifies the number of worker threads to use for `lingui check missing`.
+
+Pass `--workers 1` to disable workers and run everything in a single process.
+
+By default, the tool uses a simple heuristic:
+
+- On machines with more than 2 cores → `cpu.count - 1` workers
+- On 2-core machines → all cores
+
+Use the `--verbose` flag to see the actual pool size.
 
 ## Configuring the Source Locale
 


### PR DESCRIPTION
# Description

This PR adds a dedicated `lingui check` command for validating catalogs without writing output files.

It is based on #2506 and clarifies the mismatch between `lingui extract` "Missing" counts and `lingui compile --strict` behavior when `fallbackLocales` are configured.

It also closes #2195 by adding a CI-friendly way to check catalogs without running compilation.

Included in this PR:

- `lingui check missing` to fail on raw missing translations before fallbacks are applied
- `lingui check sync` to fail when catalogs are out of sync with `lingui extract`

In `packages/format-po/src/po.ts`, PO serialization was updated to preserve meaningful existing header state, merge custom headers deterministically, and drop empty default gettext headers. This makes serialization more stable and avoids noisy diffs, which is important for `check sync`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Examples update

Fixes #2195
Related to #2506

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
